### PR TITLE
Added + to the prepare value array, in order to get it replaced

### DIFF
--- a/app/code/community/Netzarbeiter/NicerImageNames/Helper/Image.php
+++ b/app/code/community/Netzarbeiter/NicerImageNames/Helper/Image.php
@@ -171,7 +171,7 @@ class Netzarbeiter_NicerImageNames_Helper_Image extends Mage_Catalog_Helper_Imag
             $value = strtr($value, array(
                 '%' => '',  ' ' => '-', '#'  => '-', '"' => '-', '<' => '-',
                 "'" => '-', ':' => '-', '..' => '_', '/' => '-', '_' => '-',
-                '>' => '-',
+                '>' => '-', '+' => '-'
             ));
             $value = Mage::helper('catalog/product_url')->format($value);
             $value = strtr($value, array('ã' => 'a'));


### PR DESCRIPTION
When there is a plus in an attribute which is used to compile the filename, I got a filename like: 

-katoen-kreta-blue-dreamcatcher-kreta-blue-dekbedovertrek-240x200-220-+-2-x-60x70-overtrekset-vndck-20.jpg

The result was the following filename: 

-katoen-kreta-blue-dreamcatcher-kreta-blue-dekbedovertrek-240x200-220-%20-2-x-60x70-overtrekset-vndck-20.jpg

This resulted in a 404 message for this image. Added the + char to the special characters in order to resolve this.